### PR TITLE
Fix for border hopping

### DIFF
--- a/src/main/resources/data/siege/games/villagers_vs_pillagers.json
+++ b/src/main/resources/data/siege/games/villagers_vs_pillagers.json
@@ -2,7 +2,7 @@
   "type": "siege:siege",
   "name": "Siege",
   "map": {
-    "id": "siege:villagers_vs_pillagers",
+    "id": "siuol:vvpfix",
     "attacker_spawn_angle": 180
   },
   "players": {


### PR DESCRIPTION

In this PR I did the following:

Fixed bug where you could jump into the inner castle area thing.

Must resist funny Kyanite/Consistency+ Quip

Also yes I know it uses my map ID but that can be fixed later.
